### PR TITLE
Changes for thread safety

### DIFF
--- a/Sources/write_mgrid.f
+++ b/Sources/write_mgrid.f
@@ -303,98 +303,133 @@ C-----------------------------------------------
       WRITE (6, '(a,i6,a,i6)') ' TOTAL COILS IN GROUP: ', numcoils,            &
      &                         ' TOTAL FILAMENTS: ', numfils
 
+!     Parallel grid fill: use collapsed trip loops when no symmetry fill is
+!     required so each (i,j,k) is written by exactly one iteration (OpenMP-safe).
+      IF (.not. lstell_sym) THEN
+
 !$omp parallel default(shared) private(i, j, k, zee, rad, phi)
-
-      k = 1                     ! this is always a symmetry plane
-      phi = (k - 1)*delp
-
-!$omp do
-      DO j = 1, jz2 + jz_odd
-         zee = zmin + (j - 1)*delz
-         DO i = 1, ir
-            rad = rmin + (i - 1)*delr
-            CALL bfield(rad, phi, zee, br(i,j,k),
-     &                  bp(i,j,k), bz(i,j,k), ig)
-
-            IF (lstell_sym) THEN
-               br(i,jz + 1 - j,k) = -br(i,j,k)
-               bz(i,jz + 1 - j,k) =  bz(i,j,k)
-               bp(i,jz + 1 - j,k) =  bp(i,j,k)
-            END IF
-
-            CALL afield (rad, phi, zee, ar(i,j,k),                             &
-     &                   ap(i,j,k), az(i,j,k), ig)
-
-            IF (lstell_sym) THEN
-               ar(i,jz + 1 - j,k) = -ar(i,j,k)
-               az(i,jz + 1 - j,k) =  az(i,j,k)
-               ap(i,jz + 1 - j,k) =  ap(i,j,k)
-            END IF
-
-         END DO
-      END DO
-!$omp end do
-      IF (kp .ne. 1) THEN
-!$omp single
-         WRITE (6, '(a,i4,a,i4,a)') ' K = ',k,' (OUT OF ',KP,')'
-!$omp end single
-      END IF
-
-!$omp do
-      DO k = 2, kp2 + kp_odd
-         phi = (k - 1)*delp
-         DO j = 1, jz
-            zee = zmin + (j - 1)*delz
-            DO i = 1, ir
-               rad = rmin + (i - 1)*delr
-               CALL bfield(rad, phi, zee, br(i,j,k),                           &
-     &                     bp(i,j,k), bz(i,j,k), ig)
-               IF (lstell_sym) THEN
-                  br(i,jz + 1 - j,kp + 2 - k) = -br(i,j,k)
-                  bz(i,jz + 1 - j,kp + 2 - k) =  bz(i,j,k)
-                  bp(i,jz + 1 - j,kp + 2 - k) =  bp(i,j,k)
-               END IF
-
-               CALL afield(rad, phi, zee, ar(i,j,k),                           &
-     &                     ap(i,j,k), az(i,j,k), ig)
-               IF (lstell_sym) THEN
-                  ar(i,jz + 1 - j,kp + 2 - k) = -ar(i,j,k)
-                  az(i,jz + 1 - j,kp + 2 - k) =  az(i,j,k)
-                  ap(i,jz + 1 - j,kp + 2 - k) =  ap(i,j,k)
-               END IF
+!$omp do collapse(3) schedule(static)
+         DO k = 1, kp
+            DO j = 1, jz
+               DO i = 1, ir
+                  phi = (k - 1)*delp
+                  zee = zmin + (j - 1)*delz
+                  rad = rmin + (i - 1)*delr
+!     bfield/afield share Biot-Savart state; serialize for bit-identical output.
+!$omp critical(mgrid_bs_eval)
+                  CALL bfield(rad, phi, zee, br(i,j,k),                         &
+     &                        bp(i,j,k), bz(i,j,k), ig)
+                  CALL afield(rad, phi, zee, ar(i,j,k),                       &
+     &                        ap(i,j,k), az(i,j,k), ig)
+!$omp end critical(mgrid_bs_eval)
+               END DO
             END DO
          END DO
-         WRITE (6,'(a,i4)') ' K = ',k
-      END DO
 !$omp end do
+!$omp end parallel
 
-      IF ((kp_odd .eq. 0) .and. lstell_sym) THEN       ! another symmetry plane
-         k = kp2 + 1
+      ELSE
+
+!$omp parallel default(shared) private(i, j, k, zee, rad, phi)
+
+         k = 1                     ! this is always a symmetry plane
          phi = (k - 1)*delp
+
 !$omp do
          DO j = 1, jz2 + jz_odd
             zee = zmin + (j - 1)*delz
             DO i = 1, ir
                rad = rmin + (i - 1)*delr
-               CALL bfield(rad, phi, zee, br(i,j,k),                           &
+!$omp critical(mgrid_bs_eval)
+               CALL bfield(rad, phi, zee, br(i,j,k),
      &                     bp(i,j,k), bz(i,j,k), ig)
-               br(i,jz + 1 - j,k) = -br(i,j,k)
-               bz(i,jz + 1 - j,k) =  bz(i,j,k)
-               bp(i,jz + 1 - j,k) =  bp(i,j,k)
 
-               CALL afield (rad, phi, zee, ar(i,j,k),                          &
+               IF (lstell_sym) THEN
+                  br(i,jz + 1 - j,k) = -br(i,j,k)
+                  bz(i,jz + 1 - j,k) =  bz(i,j,k)
+                  bp(i,jz + 1 - j,k) =  bp(i,j,k)
+               END IF
+
+               CALL afield (rad, phi, zee, ar(i,j,k),                           &
      &                      ap(i,j,k), az(i,j,k), ig)
-               ar(i,jz + 1 - j,k) = -ar(i,j,k)
-               az(i,jz + 1 - j,k) =  az(i,j,k)
-               ap(i,jz + 1 - j,k) =  ap(i,j,k)
+
+               IF (lstell_sym) THEN
+                  ar(i,jz + 1 - j,k) = -ar(i,j,k)
+                  az(i,jz + 1 - j,k) =  az(i,j,k)
+                  ap(i,jz + 1 - j,k) =  ap(i,j,k)
+               END IF
+!$omp end critical(mgrid_bs_eval)
+
             END DO
          END DO
 !$omp end do
+         IF (kp .ne. 1) THEN
 !$omp single
-         WRITE (6,'(a,i4)') ' K = ',k
+            WRITE (6, '(a,i4,a,i4,a)') ' K = ',k,' (OUT OF ',KP,')'
 !$omp end single
-      END IF
+         END IF
+
+!$omp do
+         DO k = 2, kp2 + kp_odd
+            phi = (k - 1)*delp
+            DO j = 1, jz
+               zee = zmin + (j - 1)*delz
+               DO i = 1, ir
+                  rad = rmin + (i - 1)*delr
+!$omp critical(mgrid_bs_eval)
+                  CALL bfield(rad, phi, zee, br(i,j,k),                        &
+     &                        bp(i,j,k), bz(i,j,k), ig)
+                  IF (lstell_sym) THEN
+                     br(i,jz + 1 - j,kp + 2 - k) = -br(i,j,k)
+                     bz(i,jz + 1 - j,kp + 2 - k) =  bz(i,j,k)
+                     bp(i,jz + 1 - j,kp + 2 - k) =  bp(i,j,k)
+                  END IF
+
+                  CALL afield(rad, phi, zee, ar(i,j,k),                        &
+     &                        ap(i,j,k), az(i,j,k), ig)
+                  IF (lstell_sym) THEN
+                     ar(i,jz + 1 - j,kp + 2 - k) = -ar(i,j,k)
+                     az(i,jz + 1 - j,kp + 2 - k) =  az(i,j,k)
+                     ap(i,jz + 1 - j,kp + 2 - k) =  ap(i,j,k)
+                  END IF
+!$omp end critical(mgrid_bs_eval)
+               END DO
+            END DO
+            WRITE (6,'(a,i4)') ' K = ',k
+         END DO
+!$omp end do
+
+         IF ((kp_odd .eq. 0) .and. lstell_sym) THEN       ! another symmetry plane
+            k = kp2 + 1
+            phi = (k - 1)*delp
+!$omp do
+            DO j = 1, jz2 + jz_odd
+               zee = zmin + (j - 1)*delz
+               DO i = 1, ir
+                  rad = rmin + (i - 1)*delr
+!$omp critical(mgrid_bs_eval)
+                  CALL bfield(rad, phi, zee, br(i,j,k),                        &
+     &                        bp(i,j,k), bz(i,j,k), ig)
+                  br(i,jz + 1 - j,k) = -br(i,j,k)
+                  bz(i,jz + 1 - j,k) =  bz(i,j,k)
+                  bp(i,jz + 1 - j,k) =  bp(i,j,k)
+
+                  CALL afield (rad, phi, zee, ar(i,j,k),                       &
+     &                         ap(i,j,k), az(i,j,k), ig)
+                  ar(i,jz + 1 - j,k) = -ar(i,j,k)
+                  az(i,jz + 1 - j,k) =  az(i,j,k)
+                  ap(i,jz + 1 - j,k) =  ap(i,j,k)
+!$omp end critical(mgrid_bs_eval)
+               END DO
+            END DO
+!$omp end do
+!$omp single
+            WRITE (6,'(a,i4)') ' K = ',k
+!$omp end single
+         END IF
 !$omp end parallel
+
+      END IF
 
       IF (mgrid_mode .eq. 'R') THEN
 !  JDH 2011-080-16. Comment out below (1 line)


### PR DESCRIPTION
1. Files changed in the repository

Two areas were modified: MAKEGRID (compute_bfield in [MAKEGRID/Sources/write_mgrid.f] and LIBSTELL ([LIBSTELL/Sources/Modules/bsc_T.f].

A. [write_mgrid.f] — SUBROUTINE compute_bfield

Problem: With multiple OpenMP threads, results differed from a single-thread run: NetCDF B and A components that should be exactly zero (for a constructed cancellation case) showed small non-zeros. Serial OMP_NUM_THREADS=1matched expectations; parallel runs did not. Investigation showed concurrent calls to bfield / afield (which call into libstellBiot–Savart) were not safe to execute in parallel on the current code path.

Changes:

LSTELL_SYM = .false. (full toroidal / no Z symmetry shortcut)

Replaced the older multi-!$omp do structure with a single !$omp parallel / !$omp do collapse(3) schedule(static) over DO k / DO j / DO i, with phi / zee / rad computed in the innermost loop so Intel Fortran’s collapse(3) rules (“perfectly nested loops”) are satisfied (and the directive was split across lines to satisfy fixed-form / compiler parsing). 

Wrapped CALL bfield and CALL afield in !$omp critical(mgrid_bs_eval) … !$omp end critical(mgrid_bs_eval) so Biot–Savart evaluation is serialized and output matches single-thread behavior for this test.

LSTELL_SYM = .true. (stellarator symmetry fill)

The symmetry branch still uses the original three-block layout (half Z, interior phi, optional extra plane). Initially it lacked the same critical wrapper; non-zero residuals appeared only in symmetric runs under OpenMP. 

Added the same mgrid_bs_eval critical region around each bfield + mirror assignments + afield + mirror assignments sequence in all three symmetry loops, so parallel runs agree with serial runs for the cancellation tests.

Trade-off: The critical regions limit parallel speedup for the field evaluation itself, until libstell can be proven (or refactored to be) thread-safe for concurrent bfield/afield calls; the loops still structure work for future removal of the critical if the library is fixed.

B. [bsc_T.f]— bsc_a_coil_a and bsc_b_coil_a

Problem: Summing coil contributions with SUM(array, dim=2) can use compiler/library optimizations (vectorization, parallel reductions) whose evaluation order can differ from a simple sequential sum. For near-cancellation cases (opposing currents), that can change floating-point results; this was an extra guard for reproducibility when OpenMP is enabled.

Change: Replaced
a(1:3) = SUM(aarray(1:3,1:n),2) and b = SUM(barray(1:3,1:n),2) with explicit DO loops that accumulate a(1:3) and b(1:3) coil-by-coil in a fixed order, initialized from zero.

Note: The dominant parallel bug was addressed by critical in compute_bfield; the explicit sums are a robustnessimprovement and do not replace the need for thread-safe Biot–Savart if critical is removed later.
